### PR TITLE
use init instead of enqueue_block_assets to hook gutenberg_block_setup

### DIFF
--- a/cookiebot.php
+++ b/cookiebot.php
@@ -210,7 +210,7 @@ final class Cookiebot_WP {
 		
 		
 		//Add Gutenberg block
-		add_action( 'enqueue_block_assets', array($this,'gutenberg_block_setup') );
+		add_action( 'init', array($this,'gutenberg_block_setup') );
 		add_action( 'enqueue_block_editor_assets', array($this,'gutenberg_block_admin_assets') );   
 	}
 	


### PR DESCRIPTION
This commit fixes an PHP Notice with WP_Block_Type_Registry::register
(https://github.com/CybotAS/CookiebotWP/issues/193)